### PR TITLE
revert: pin rumdl to v0.1.62 until v0.1.72 attestation is fixed

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -25,7 +25,7 @@ PIP_INDEX_URL = "{{ get_env(name='PIP_INDEX_URL', default='') }}"
 
 [tools]
 "aqua:casey/just" = "1.49.0"
-"aqua:rvben/rumdl" = "v0.1.72"
+"aqua:rvben/rumdl" = "v0.1.62"
 "aqua:google/yamlfmt" = "v0.21.0"
 "aqua:rhysd/actionlint" = "v1.7.12"
 "aqua:zricethezav/gitleaks" = "v8.30.1"

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,14 @@
       "/(^|/)\\.mise\\.toml$/"
     ]
   },
+  "packageRules": [
+    {
+      "description": "Skip rumdl v0.1.72 — aqua attestation verification fails (upstream workflow-ref pattern mismatch)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["rvben/rumdl"],
+      "allowedVersions": "!=v0.1.72"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Revert #200 (db4f25f) which bumped aqua:rvben/rumdl to v0.1.72. That version fails mise's paranoid attestation check on every CI run:

  mise ERROR Failed to install aqua:rvben/rumdl@v0.1.72: GitHub
  artifact attestations verification failed: Verification failed:
  Workflow verification failed: expected
  'rvben/rumdl/\.github/workflows/release\.yml', found certificate:
  Some(".../release.yml@refs/tags/v0.1.72"), provenance:
  Some(".github/workflows/release.yml")

The aqua registry's workflow-ref regex includes the `rvben/rumdl/` repo prefix, but v0.1.72's provenance statement embeds only `.github/workflows/release.yml`. Mismatch is upstream — either in the aqua-registry entry for rumdl or in rumdl's release workflow.

Also ignore v0.1.72 in renovate so the broken version is not proposed again until the upstream mismatch is resolved.

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [ ] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
